### PR TITLE
Fixes some small typos

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,9 @@
         "stylelint.vscode-stylelint",
         "yzhang.markdown-all-in-one",
         // Git
-        "mhutchie.git-graph"
+        "mhutchie.git-graph",
+        // Spell check
+        "streetsidesoftware.code-spell-checker"
       ]
     }
   }

--- a/_posts/2024-01-21-docsis-hacking-puma-6-and-7.md
+++ b/_posts/2024-01-21-docsis-hacking-puma-6-and-7.md
@@ -53,7 +53,7 @@ armv6eb core: **192.168.254.253**, network device processor (ndp0)
        valid_lft forever preferred_lft forever
 ```
 
-i686 core: **192.168.254.254**, appication device processor (adp0)
+i686 core: **192.168.254.254**, application device processor (adp0)
 ```
 13: adp0.555@adp0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 2000 qdisc noqueue state UP group default qlen 1000
     link/ether 00:50:f1:80:00:00 brd ff:ff:ff:ff:ff:ff


### PR DESCRIPTION
Fixes a few typos and adds a spellcheck extension to your dev container. I find it very helpful when writing my own blog. 

The `yzhang.markdown-all-in-one` extension automatically formatted the tables. I can remove that if you'd like. 

Some interesting articles you have! 